### PR TITLE
jqpipe.go: exit Next on EOF error

### DIFF
--- a/jqpipe.go
+++ b/jqpipe.go
@@ -97,7 +97,7 @@ func (p *Pipe) Next() (json.RawMessage, error) {
 		return nil, errors.New(p.stderr.String())
 	}
 
-	if p.jq.ProcessState.Success() {
+	if p.jq.ProcessState.Success() || err == io.EOF {
 		return nil, io.EOF
 	}
 


### PR DESCRIPTION
`Next()` will return null if we don't check for an EOF error.

Fixes #6 