### PR TITLE
Let 'jq' call run to completion

### DIFF
--- a/jqpipe.go
+++ b/jqpipe.go
@@ -12,6 +12,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"os/exec"
 )
@@ -88,8 +89,7 @@ func (p *Pipe) Next() (json.RawMessage, error) {
 		return nil, err
 	}
 
-	// terminate jq (if it hasn't died already)
-	p.jq.Process.Kill()
+	// wait for the program to exit on its own
 	p.jq.Wait()
 
 	// if jq complained, that's our error
@@ -101,7 +101,8 @@ func (p *Pipe) Next() (json.RawMessage, error) {
 		return nil, io.EOF
 	}
 
-	return nil, errors.New("unexplained jq failure")
+	// provide detailed state and error information if we reach this point
+	return nil, errors.New(fmt.Sprintf("unexplained jq failure - processState: %s, err: %s", p.jq.ProcessState.String(), err.Error()))
 }
 
 // Close attempts to halt the jq process if it has not already exited.  This is only necessary if Next has not returned io.EOF.

--- a/jqpipe.go
+++ b/jqpipe.go
@@ -102,7 +102,7 @@ func (p *Pipe) Next() (json.RawMessage, error) {
 		return nil, io.EOF
 	}
 
-	return nil, errors.New(fmt.Sprintf("unexplained jq failure - processState: %s", p.jq.ProcessState.String()))
+	return nil, errors.New(fmt.Sprintf("unexplained jq failure - processState: %s, err: %s", p.jq.ProcessState.String(), err.Error()))
 }
 
 // Close attempts to halt the jq process if it has not already exited.  This is only necessary if Next has not returned io.EOF.

--- a/jqpipe.go
+++ b/jqpipe.go
@@ -90,7 +90,7 @@ func (p *Pipe) Next() (json.RawMessage, error) {
 	}
 
 	// terminate jq (if it hasn't died already)
-	p.jq.Process.Kill()
+	defer p.jq.Process.Kill()
 	p.jq.Wait()
 
 	// if jq complained, that's our error

--- a/jqpipe.go
+++ b/jqpipe.go
@@ -12,6 +12,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"os/exec"
 )
@@ -101,7 +102,7 @@ func (p *Pipe) Next() (json.RawMessage, error) {
 		return nil, io.EOF
 	}
 
-	return nil, errors.New("unexplained jq failure")
+	return nil, errors.New(fmt.Sprintf("unexplained jq failure - processState: %s", p.jq.ProcessState.String()))
 }
 
 // Close attempts to halt the jq process if it has not already exited.  This is only necessary if Next has not returned io.EOF.


### PR DESCRIPTION
We've found that when running the `Kill()` on the process before the `Wait()` we quite often run into the `unexplained jq failure`. After some playing with it and enhancing the error message we noticed that the program had an `io.EOF` error and should have exited normally. 
We suspect that in some cases the program gets killed prematurely so that instead of `Success()`, it gets `Killed()` as its process status when things otherwise finish without problems.
After removing the `Kill()` we don't see the `unexplained` errors anymore.